### PR TITLE
fix(scripts): add PATCH support to apply-org-rulesets for drift correction

### DIFF
--- a/scripts/apply-org-rulesets.sh
+++ b/scripts/apply-org-rulesets.sh
@@ -28,14 +28,7 @@ get_ruleset_id() {
 RULESET_NAME="Main Branch Protection"
 EXISTING_ID="$(get_ruleset_id "${RULESET_NAME}")"
 
-if [[ -n "${EXISTING_ID}" ]]; then
-  echo "Ruleset '${RULESET_NAME}' already exists (id=${EXISTING_ID}). Skipping."
-else
-  echo "Creating ruleset '${RULESET_NAME}'..."
-  gh api --method POST "/orgs/${ORG}/rulesets" \
-    --header "Content-Type: application/json" \
-    --input - <<'EOF'
-{
+MAIN_BRANCH_PAYLOAD='{
   "name": "Main Branch Protection",
   "target": "branch",
   "enforcement": "evaluate",
@@ -92,8 +85,19 @@ else
       }
     }
   ]
-}
-EOF
+}'
+
+if [[ -n "${EXISTING_ID}" ]]; then
+  echo "Ruleset '${RULESET_NAME}' exists (id=${EXISTING_ID}). Patching..."
+  echo "${MAIN_BRANCH_PAYLOAD}" | gh api --method PATCH "/orgs/${ORG}/rulesets/${EXISTING_ID}" \
+    --header "Content-Type: application/json" \
+    --input -
+  echo "Ruleset '${RULESET_NAME}' patched."
+else
+  echo "Creating ruleset '${RULESET_NAME}'..."
+  echo "${MAIN_BRANCH_PAYLOAD}" | gh api --method POST "/orgs/${ORG}/rulesets" \
+    --header "Content-Type: application/json" \
+    --input -
   echo "Ruleset '${RULESET_NAME}' created."
 fi
 
@@ -102,14 +106,7 @@ fi
 RULESET_NAME="Release Tag Protection"
 EXISTING_ID="$(get_ruleset_id "${RULESET_NAME}")"
 
-if [[ -n "${EXISTING_ID}" ]]; then
-  echo "Ruleset '${RULESET_NAME}' already exists (id=${EXISTING_ID}). Skipping."
-else
-  echo "Creating ruleset '${RULESET_NAME}'..."
-  gh api --method POST "/orgs/${ORG}/rulesets" \
-    --header "Content-Type: application/json" \
-    --input - <<'EOF'
-{
+RELEASE_TAG_PAYLOAD='{
   "name": "Release Tag Protection",
   "target": "tag",
   "enforcement": "active",
@@ -138,8 +135,19 @@ else
   "rules": [
     { "type": "creation" }
   ]
-}
-EOF
+}'
+
+if [[ -n "${EXISTING_ID}" ]]; then
+  echo "Ruleset '${RULESET_NAME}' exists (id=${EXISTING_ID}). Patching..."
+  echo "${RELEASE_TAG_PAYLOAD}" | gh api --method PATCH "/orgs/${ORG}/rulesets/${EXISTING_ID}" \
+    --header "Content-Type: application/json" \
+    --input -
+  echo "Ruleset '${RULESET_NAME}' patched."
+else
+  echo "Creating ruleset '${RULESET_NAME}'..."
+  echo "${RELEASE_TAG_PAYLOAD}" | gh api --method POST "/orgs/${ORG}/rulesets" \
+    --header "Content-Type: application/json" \
+    --input -
   echo "Ruleset '${RULESET_NAME}' created."
 fi
 


### PR DESCRIPTION
## Summary

Script was create-only; existing rulesets were silently skipped with no update applied.
Both rulesets now PATCH when they already exist and POST when they do not, making the script fully idempotent and safe to re-run after any drift.

## Changes

- `scripts/apply-org-rulesets.sh`: extracted JSON payloads into named variables; replaced skip-on-existing with PATCH call for both \`Main Branch Protection\` and \`Release Tag Protection\`

## Test plan

- [ ] Dry run (`./scripts/apply-org-rulesets.sh true`) still lists rulesets and exits cleanly
- [ ] Re-running against an org with both rulesets already present PATCHes without error
- [ ] Running against an org with no rulesets POSTs both and creates them correctly

Closes #2