### PR TITLE
chore(ci): bump clouatre-labs/aptu action to v0.10.1

### DIFF
--- a/workflows/issue-triage.yml
+++ b/workflows/issue-triage.yml
@@ -1,0 +1,24 @@
+name: Triage New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  triage:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run Aptu Triage
+        uses: clouatre-labs/aptu@5545c56f0f4bf52a3dc918ec48a56c309280447c # v0.10.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          no-comment: 'true'

--- a/workflows/pr-review.yml
+++ b/workflows/pr-review.yml
@@ -1,0 +1,36 @@
+name: Review Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+      attestations: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Review PR
+        uses: clouatre-labs/aptu@5545c56f0f4bf52a3dc918ec48a56c309280447c # v0.10.1
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          provider: gemini
+          model: gemini-3.1-flash-lite-preview
+          skip-labeled: 'false'
+          fallback-provider: 'openrouter'
+          fallback-model: 'inception/mercury-2'
+          instructions-file: .github/instructions/pr-review.md
+          repo-path: ${{ github.workspace }}


### PR DESCRIPTION
Bumps `clouatre-labs/aptu` GitHub Action from v0.8.1 to v0.10.1.

SHA pin: `5545c56f0f4bf52a3dc918ec48a56c309280447c`

Release: https://github.com/clouatre-labs/aptu/releases/tag/v0.10.1
